### PR TITLE
AS#118090147171048, Mail chimp Integration

### DIFF
--- a/constants.coffee
+++ b/constants.coffee
@@ -6,6 +6,7 @@ configEnvConstants = (ENV) ->
     API_URL           : 'https://api.topcoder-dev.com/v3'
     API_URL_V2        : 'https://api.topcoder-dev.com/v2'
     WORK_API_URL      : 'https://api-work.topcoder-dev.com/v3'
+    INTERNAL_API_URL  : 'https://internal-api.topcoder-dev.com/v3'
     ASSET_PREFIX      : 'https://s3.amazonaws.com/app.topcoder-dev.com/'
     AUTH_API_URL      : 'https://api.topcoder-dev.com/v3'
     auth0Callback     : 'https://api.topcoder-dev.com/pub/callback.html'
@@ -26,8 +27,16 @@ configEnvConstants = (ENV) ->
     HELP_APP_URL       : 'help.topcoder-dev.com'
     MAIN_URL           : 'https://www.topcoder-dev.com'
     PHOTO_LINK_LOCATION: 'https://community.topcoder-dev.com'
-    SWIFT_PROGRAM_URL  : 'apple.topcoder-dev.com',
+    SWIFT_PROGRAM_URL  : 'apple.topcoder-dev.com'
     TCO16_URL          : 'http://tco16.topcoder-dev.com'
+
+    # Mailchimp
+    MAILCHIMP_LIST_ID       : '72cdd94102'
+    MAILCHIMP_NL_TCO        : '4376e08f1e'
+    MAILCHIMP_NL_IOS        : '11d81965bb'
+    MAILCHIMP_NL_DEV        : 'e0986266dc'
+    MAILCHIMP_NL_DESIGN     : '9d1b672a99'
+    MAILCHIMP_NL_DATA       : 'cc118bd550'
 
 
   if ENV == 'QA'
@@ -35,6 +44,7 @@ configEnvConstants = (ENV) ->
     API_URL           : 'https://api.topcoder-qa.com/v3'
     API_URL_V2        : 'https://api.topcoder-qa.com/v2'
     WORK_API_URL      : 'https://api-work.topcoder-qa.com/v3'
+    INTERNAL_API_URL  : 'https://internal-api.topcoder-qa.com/v3'
     ASSET_PREFIX      : 'https://s3.amazonaws.com/app.topcoder-qa.com/'
     AUTH_API_URL      : 'https://api.topcoder-qa.com/v3'
     auth0Callback     : 'https://api.topcoder-qa.com/pub/callback.html'
@@ -58,11 +68,20 @@ configEnvConstants = (ENV) ->
     SWIFT_PROGRAM_URL  : 'apple.topcoder-qa.com',
     TCO16_URL          : 'http://tco16.topcoder-qa.com'
 
+    # Mailchimp
+    MAILCHIMP_LIST_ID       : '72cdd94102'
+    MAILCHIMP_NL_TCO        : '4376e08f1e'
+    MAILCHIMP_NL_IOS        : '11d81965bb'
+    MAILCHIMP_NL_DEV        : 'e0986266dc'
+    MAILCHIMP_NL_DESIGN     : '9d1b672a99'
+    MAILCHIMP_NL_DATA       : 'cc118bd550'
+
   if ENV == 'PROD'
     Object.assign constants,
     API_URL           : 'https://api.topcoder.com/v3'
     API_URL_V2        : 'https://api.topcoder.com/v2'
     WORK_API_URL      : 'https://api-work.topcoder.com/v3'
+    INTERNAL_API_URL  : 'https://internal-api.topcoder.com/v3'
     ASSET_PREFIX      : 'https://s3.amazonaws.com/app.topcoder.com/'
     AUTH_API_URL      : 'https://api.topcoder.com/v3'
     auth0Callback     : 'https://api.topcoder.com/pub/callback.html'
@@ -86,6 +105,14 @@ configEnvConstants = (ENV) ->
     PHOTO_LINK_LOCATION: 'https://community.topcoder.com'
     SWIFT_PROGRAM_URL  : 'apple.topcoder.com',
     TCO16_URL          : 'http://tco16.topcoder.com'
+
+    # Mailchimp
+    MAILCHIMP_LIST_ID       : '72cdd94102'
+    MAILCHIMP_NL_TCO        : '4376e08f1e'
+    MAILCHIMP_NL_IOS        : '11d81965bb'
+    MAILCHIMP_NL_DEV        : 'e0986266dc'
+    MAILCHIMP_NL_DESIGN     : '9d1b672a99'
+    MAILCHIMP_NL_DATA       : 'cc118bd550'
 
   constants
 


### PR DESCRIPTION
-- Added constants

@parthshah @nlitwin @aselbie I have to add many constants for mailchimp. While MAILCHIMP_LIST_ID is required(please let me know if otherwise) in any case, I can get rid of constants for ids of newsletters by making one extra mailchimp api call. However, for getting first version out and saving one extra http call on skill-picker page load, I have added them. Now, my concern is the security. Should we really commit these ids in github? Even if get it using calling mailchimp api, we would have these ids in plain text in the calling page (skill picker for topcoder-app). Please note, right now I have copied, for all 3 env, the ids of a temporary list which I have created for testing. So, in case, we decide not to include these ids in github, I can safely remove these newsletters from the temporary list and recreated new one for testing.