### PR TITLE
Asana Task#251570416879588, Add IBM Cognitive opt-in to Skill Picker upon account activation and preferences page

### DIFF
--- a/constants.coffee
+++ b/constants.coffee
@@ -38,8 +38,9 @@ configEnvConstants = (ENV) ->
     FILE_PICKER_API_KEY: 'AzFINuQoqTmqw0QEoaw9az'
     FILE_PICKER_SUBMISSION_CONTAINER_NAME: 'submission-staging-dev'
 
-    PREDIX_PROGRAM_ID  : 3448
-    HEAP_ANALYTICS_APP_ID : '4153837120'
+    PREDIX_PROGRAM_ID         : 3448
+    IBM_COGNITIVE_PROGRAM_ID  : 3449
+    HEAP_ANALYTICS_APP_ID     : '4153837120'
 
   if ENV == 'QA'
     Object.assign constants,
@@ -78,8 +79,9 @@ configEnvConstants = (ENV) ->
     FILE_PICKER_API_KEY: 'ACrnuL2lqRAOOHLOhqwkaz'
     FILE_PICKER_SUBMISSION_CONTAINER_NAME: 'submission-staging-qa'
 
-    PREDIX_PROGRAM_ID  : 3448
-    HEAP_ANALYTICS_APP_ID : '4153837120'
+    PREDIX_PROGRAM_ID         : 3448
+    IBM_COGNITIVE_PROGRAM_ID  : 3449
+    HEAP_ANALYTICS_APP_ID     : '4153837120'
 
   if ENV == 'PROD'
     Object.assign constants,
@@ -119,8 +121,9 @@ configEnvConstants = (ENV) ->
     FILE_PICKER_API_KEY: 'ABqZ3MVqqSeiqL2fMOjTxz'
     FILE_PICKER_SUBMISSION_CONTAINER_NAME: 'submission-staging-prod'
 
-    PREDIX_PROGRAM_ID  : 3448
-    HEAP_ANALYTICS_APP_ID : '638908330'
+    PREDIX_PROGRAM_ID         : 3448
+    IBM_COGNITIVE_PROGRAM_ID  : 3449
+    HEAP_ANALYTICS_APP_ID     : '638908330'
 
   constants
 


### PR DESCRIPTION
-- Constants config for IBM Cognitive community

fyi @ajefts I am assuming we have same id in qa and production environments.